### PR TITLE
ci(next.config): add vercel storage to remote image patterns

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -21,16 +21,22 @@ const nextConfig = {
   images: {
     remotePatterns: [
       {
-        protocol: 'https',
-        hostname: 'wechatapppro-1252524126.cos.ap-shanghai.myqcloud.com',
-        port: '',
-        pathname: '/**',
+        protocol: "https",
+        hostname: "wechatapppro-1252524126.cos.ap-shanghai.myqcloud.com",
+        port: "",
+        pathname: "/**",
       },
       {
-        protocol: 'https',
-        hostname: 'images.unsplash.com',
-        port: '',
-        pathname: '/**',
+        protocol: "https",
+        hostname: "images.unsplash.com",
+        port: "",
+        pathname: "/**",
+      },
+      {
+        protocol: "https",
+        hostname: "*.public.blob.vercel-storage.com",
+        port: "",
+        pathname: "/**",
       },
     ],
   },


### PR DESCRIPTION
This change adds '*.public.blob.vercel-storage.com' to the list of allowed remote image patterns in the Next.js configuration. This is necessary to support images hosted on Vercel's storage service, ensuring they are properly loaded and optimized by the Next.js image component.